### PR TITLE
APP-855 Adição do envio do token dinâmico para a função de inicialização

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 .vscode/
 *.iml
 *.lock
+android/.project
+
+example/android/app/.project

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation "com.github.tamojuno:direct-checkout-android:1.0.2"
+        implementation "com.github.tamojuno:direct-checkout-android:1.0.3"
         implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61'
     }
 }

--- a/android/src/main/java/br/com/juno/juno_direct_checkout/JunoDirectCheckoutPlugin.java
+++ b/android/src/main/java/br/com/juno/juno_direct_checkout/JunoDirectCheckoutPlugin.java
@@ -51,11 +51,14 @@ public class JunoDirectCheckoutPlugin implements FlutterPlugin, MethodCallHandle
     switch (call.method) {
       case "init": 
         Boolean prod = true;
+        final String token = call.argument("public_token");
+
         if (call.hasArgument("prod")) {
           prod = call.argument("prod");
         }
+
         InitializeDirectCheckoutListener initializeListener = new InitializeDirectCheckoutListener(result);
-        DirectCheckout.initialize(context, prod, initializeListener);
+        DirectCheckout.initialize(context, prod, token, initializeListener);
         break;
       case "getCardHash":
         CodigoHashDirectCheckoutListener listener = new CodigoHashDirectCheckoutListener(result);


### PR DESCRIPTION
## O que
Foi solicitado que fosse ajustado no SDK o aceite de do token dinâmico além do que esta registrado no arquivo Manifest. 

## Por que
Alguns favorecidos precisam que seja passível considerar o token dinâmico. 

## Como
Ao chamar a função de inicialização é pego no map enviado o token dinâmico e enviado para a função de inicialização do SDK Android. E atualização da versão do SDK Android

## Referências
[Issue APP-855](https://boleto.atlassian.net/browse/APP-855)